### PR TITLE
pricing: one rate card across Blockfrost, Kupo, Ogmios and UTxO RPC

### DIFF
--- a/bootstrap/rpc/crds/blockfrostport.json
+++ b/bootstrap/rpc/crds/blockfrostport.json
@@ -17,14 +17,14 @@
     "2": {
       "dns": "demeter.run",
       "cost": {
-        "minimum": 30,
+        "minimum": 50,
         "delta": 0.0000026
       }
     },
     "3": {
       "dns": "demeter.run",
       "cost": {
-        "minimum": 80,
+        "minimum": 150,
         "delta": 0.0000023
       }
     }

--- a/bootstrap/rpc/crds/blockfrostport.json
+++ b/bootstrap/rpc/crds/blockfrostport.json
@@ -11,21 +11,21 @@
       "dns": "demeter.run",
       "cost": {
         "minimum": 0,
-        "delta": 0.0000006
+        "delta": 0.000003
       }
     },
     "2": {
       "dns": "demeter.run",
       "cost": {
         "minimum": 30,
-        "delta": 0.0000005
+        "delta": 0.0000026
       }
     },
     "3": {
       "dns": "demeter.run",
       "cost": {
         "minimum": 80,
-        "delta": 0.0000004
+        "delta": 0.0000023
       }
     }
   },

--- a/bootstrap/rpc/crds/kupoport.json
+++ b/bootstrap/rpc/crds/kupoport.json
@@ -11,21 +11,21 @@
       "dns": "dmtr.host",
       "cost": {
         "minimum": 0,
-        "delta": 0.0000009
+        "delta": 0.000003
       }
     },
     "2": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 50,
-        "delta": 0.0000008
+        "minimum": 30,
+        "delta": 0.0000026
       }
     },
     "3": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 150,
-        "delta": 0.0000007
+        "minimum": 80,
+        "delta": 0.0000023
       }
     }
   },

--- a/bootstrap/rpc/crds/kupoport.json
+++ b/bootstrap/rpc/crds/kupoport.json
@@ -17,14 +17,14 @@
     "2": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 30,
+        "minimum": 50,
         "delta": 0.0000026
       }
     },
     "3": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 80,
+        "minimum": 150,
         "delta": 0.0000023
       }
     }

--- a/bootstrap/rpc/crds/ogmiosport.json
+++ b/bootstrap/rpc/crds/ogmiosport.json
@@ -17,14 +17,14 @@
     "2": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 30,
+        "minimum": 50,
         "delta": 0.0000026
       }
     },
     "3": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 80,
+        "minimum": 150,
         "delta": 0.0000023
       }
     }

--- a/bootstrap/rpc/crds/ogmiosport.json
+++ b/bootstrap/rpc/crds/ogmiosport.json
@@ -11,21 +11,21 @@
       "dns": "dmtr.host",
       "cost": {
         "minimum": 0,
-        "delta": 0.000002662
+        "delta": 0.000003
       }
     },
     "2": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 100,
-        "delta": 0.000002315
+        "minimum": 30,
+        "delta": 0.0000026
       }
     },
     "3": {
       "dns": "dmtr.host",
       "cost": {
-        "minimum": 200,
-        "delta": 0.000001968
+        "minimum": 80,
+        "delta": 0.0000023
       }
     }
   },

--- a/bootstrap/rpc/crds/utxorpcport.json
+++ b/bootstrap/rpc/crds/utxorpcport.json
@@ -17,14 +17,14 @@
     "2": {
       "dns": "demeter.run",
       "cost": {
-        "minimum": 30,
+        "minimum": 50,
         "delta": 0.0000026
       }
     },
     "3": {
       "dns": "demeter.run",
       "cost": {
-        "minimum": 80,
+        "minimum": 150,
         "delta": 0.0000023
       }
     }

--- a/bootstrap/rpc/crds/utxorpcport.json
+++ b/bootstrap/rpc/crds/utxorpcport.json
@@ -1,16 +1,32 @@
 {
   "plan": {
     "0": {
-      "dns": "demeter.run"
+      "dns": "demeter.run",
+      "cost": {
+        "minimum": 0,
+        "delta": 0
+      }
     },
     "1": {
-      "dns": "demeter.run"
+      "dns": "demeter.run",
+      "cost": {
+        "minimum": 0,
+        "delta": 0.000003
+      }
     },
     "2": {
-      "dns": "demeter.run"
+      "dns": "demeter.run",
+      "cost": {
+        "minimum": 30,
+        "delta": 0.0000026
+      }
     },
     "3": {
-      "dns": "demeter.run"
+      "dns": "demeter.run",
+      "cost": {
+        "minimum": 80,
+        "delta": 0.0000023
+      }
     }
   },
   "options": [


### PR DESCRIPTION
Sets `plan.{0,1,2,3}.cost` on the four GA port classes one Dolos cell serves to the derived rate card. Part of a three-repository change landing one card in the three places code holds a price; the other two are `demeter-run/webui` and `demeter-run/website2`.

## Plan

- `plans/pricing-rate-card-rollout-card-in-code.md` — this piece (the code)
- `plans/pricing-rate-card-rollout.md` — the parent (the card, the money argument, and everything only the owner may do)

Both in the Trellis domain root at `~/Brain/demeter-run`. Opened by `org/coder`, which never merges its own PR.

## The card

| plan | tier | `$/100k units` | `cost.delta` | `cost.minimum` |
|---|---|---:|---:|---:|
| Free | `0` | $0 | `0` | `0` |
| Flexible | `1` | $0.30 | `0.000003` | `0` |
| Pro I | `2` | $0.26 | `0.0000026` | `50` |
| Pro II | `3` | $0.23 | `0.0000023` | `150` |

One `delta` and one `minimum` across all four classes.

> **Revised after this PR was opened.** It first carried `$0 / $30 / $80`; the second commit moves the minimums to `$0 / $50 / $150` — the owner's decision, Kupo's values rather than Blockfrost's. **Review the branch, not the first commit.** The `delta` column never moved.
>
> Against `main` that means **Kupo's minimums no longer change at all** (it already sat at `$0/$50/$150`), Blockfrost's **rise** from `$0/$30/$80`, Ogmios's **fall** from `$0/$100/$200`, and UTxO RPC gains them with the rest of its first `cost` block. On June volume the rollout is now a **~11% revenue increase** on these four classes where `$0/$30/$80` was a ~20% reduction.

## What changed

Four files, `plan.*.cost` only — `dns`, `options` and `crd` untouched, and the `.hbs` siblings carry no price.

| file | before (t1 delta · t2 min/delta · t3 min/delta) | after |
|---|---|---|
| `blockfrostport.json` | `0.0000006` · `30`/`0.0000005` · `80`/`0.0000004` | the card |
| `kupoport.json` | `0.0000009` · `50`/`0.0000008` · `150`/`0.0000007` | the card |
| `ogmiosport.json` | `0.000002662` · `100`/`0.000002315` · `200`/`0.000001968` | the card |
| `utxorpcport.json` | **no `cost` key on any tier** | the card, on all four tiers |

`utxorpcport.json` is the defect fix: with no `cost` block, `calculate_cost` takes the `None` branch, logs `cost not found`, sets no `units_cost`, and the class is **not billed at all**. It now has `cost` on tiers 0–3, `dns` first, matching `blockfrostport.json`'s key order and indentation.

Deltas are written as plain decimals to match the existing style in these files.

**Only these four.** `dbsyncport`, `cardanonodeport`, `submitapiport`, `marloweport`, `mumakport`, `scrollsport`, `trpport` and `baliusworker` keep their current cost blocks — they are outside the derivation's GA scope.

**Ogmios's unit is a connection-second, not a request.** The number is right and the unit is not, until the meter correction lands separately. That is deliberate.

## Verification

- **Published-card readback** (`solution/pricing/skills/derive-port-prices` step 1, run from the domain root) — `blockfrostport`, `kupoport`, `ogmiosport`, `utxorpcport` all print `min=$0 / $50 / $150` and `$/100k= 0.3000 / 0.2600 / 0.2300` at t1/t2/t3, and `min=$0` with `$/100k= 0.0000` at t0. PASS
- **Key presence** — that script cannot tell an absent `cost` block from a zeroed one (both print `0.0000`), which is exactly the UTxO RPC defect. Checked directly: for each of the four files and each of tiers 0–3, `plan.{tier}.cost` exists and carries both `minimum` and `delta`. PASS, 16/16
- **No drift before editing** — all four files matched their recorded prior values exactly, so no price had been changed outside this plan.
- **Blast radius** — `git diff --name-only origin/main` returns exactly the four CRD JSONs.
- `cargo test --lib` (`SQLX_OFFLINE=true`) — **145 passed, 0 failed**. PASS

### Finding: the `Clippy` check fails, and has failed on `main` since March

`cargo clippy -- -D warnings` fails on this PR. It is **pre-existing and unrelated to this change**, on three independent pieces of evidence:

1. The `Clippy` workflow's **last two runs on `main` both failed**, including the run on `a02e0584` — the exact commit this branch forks from. It has been red on `main` since 2026-03-13.
2. Run locally, the failure is **identical on pristine `origin/main` and on this branch** (verified by stashing).
3. Every error is in a `.rs` file. **This PR changes only JSON.**

CI reports `redundant reference in format! argument` and `this if can be collapsed into the outer match`; a local run on rustc 1.95 adds `result_large_err` in `src/drivers/grpc/middlewares/auth.rs`.

Reported, not fixed — widening the change to make a check pass is out of scope by construction. **Every other check on this PR is green**: `unit` (145 tests, 3m40s), `integration` (`./test/expect` against a kind cluster, 17m6s), and `plan`.

The reviewer should be aware they are merging against an already-red `Clippy` check, and that clearing it is separate work.

## Merge order — this is not free

**Merging this changes nothing by itself.** The CRDs ConfigMap is rewritten by `terraform apply` on the `rpc` module (`bootstrap/rpc/crds.tf`), and `FileMetadata::new` reads it **only at process start** — so the `fabric-rpc` StatefulSet must be restarted for the new price to take effect. Both are human acts.

Note also that `cli` compiles these JSONs in at build time (`include_dir!`), so the invoice and the Console resolve the card from two different places.

Across the three PRs:

- **webui** merging auto-deploys the Console and repricing is immediately visible against current *and historical* usage. It must not merge before the affected accounts have been notified.
- **fabric** (this PR) needs the `terraform apply` and the `fabric-rpc` restart, both human.
- **website2** publishes nothing — deployed by a human with `kubectl`, not from CI, and not serving the apex.

## What this PR is not

Not applied, not published, not merged by its author. The `terraform apply`, the restart, the Console confirmation, the customer and partner-cluster notification, the per-account price hold register, and the Ogmios meter correction all sit with the parent plan's owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


