### PR TITLE
feat: offer ogmios v7 side-by-side with v6 in the port catalog

### DIFF
--- a/bootstrap/rpc/crds/ogmiosport.json
+++ b/bootstrap/rpc/crds/ogmiosport.json
@@ -31,7 +31,7 @@
   },
   "options": [
     {
-      "description": "cardano-mainnet",
+      "description": "cardano-mainnet - v6",
       "spec": {
         "network": "cardano-mainnet",
         "throughputTier": "0",
@@ -39,7 +39,15 @@
       }
     },
     {
-      "description": "cardano-preprod",
+      "description": "cardano-mainnet - v7",
+      "spec": {
+        "network": "cardano-mainnet",
+        "throughputTier": "0",
+        "version": 7
+      }
+    },
+    {
+      "description": "cardano-preprod - v6",
       "spec": {
         "network": "cardano-preprod",
         "throughputTier": "0",
@@ -47,7 +55,15 @@
       }
     },
     {
-      "description": "cardano-preview",
+      "description": "cardano-preprod - v7",
+      "spec": {
+        "network": "cardano-preprod",
+        "throughputTier": "0",
+        "version": 7
+      }
+    },
+    {
+      "description": "cardano-preview - v6",
       "spec": {
         "network": "cardano-preview",
         "throughputTier": "0",
@@ -55,7 +71,15 @@
       }
     },
     {
-      "description": "vector-testnet",
+      "description": "cardano-preview - v7",
+      "spec": {
+        "network": "cardano-preview",
+        "throughputTier": "0",
+        "version": 7
+      }
+    },
+    {
+      "description": "vector-testnet - v6",
       "spec": {
         "network": "vector-testnet",
         "throughputTier": "0",
@@ -63,7 +87,7 @@
       }
     },
     {
-      "description": "prime-testnet",
+      "description": "prime-testnet - v6",
       "spec": {
         "network": "prime-testnet",
         "throughputTier": "0",


### PR DESCRIPTION
## What

Adds **Ogmios v7** entries to the OgmiosPort metadata catalog for `cardano-mainnet`, `cardano-preprod`, and `cardano-preview`, and suffixes every option `description` with its version (`cardano-mainnet - v6` / `cardano-mainnet - v7`, following the `cardanonodeport.json` labeling precedent) so the Console dropdown can distinguish the two.

Plan ref: demeter-run domain `plans/ogmios-v7-rollout.md`, workstream 5 (Console support). Done criterion: v7 selectable in the Console side-by-side with v6 — met by this metadata change once deployed (the Console dropdown is fed verbatim from this file via `MetadataService.FetchMetadata`).

## Notes for review

- `version` is a JSON **integer** (`7`), matching the CRD's `uint8` and the operator's `u8` spec field. No CRD schema change needed.
- No Rust change: the RPC validates only `kind`; the spec passes through opaque. Tiers (`plan`) and the `.hbs` endpoint template are version-agnostic.
- `vector-testnet` / `prime-testnet` keep v6 only (no v7 infra), but their labels get the `- v6` suffix for consistency.

## Rollout (operator action, not in this PR)

This metadata ships two ways — both must roll out:
1. the `fabric-rpc-crds` ConfigMap (`bootstrap/rpc/crds.tf`) mounted at `/fabric/crds`;
2. `include_dir!("bootstrap/rpc/crds")` compiled into the binary for backoffice/billing (`src/drivers/backoffice/mod.rs`) — needs an image rebuild.

**Sequencing guard:** deploy only after v7 instances + cert SANs + DNS exist for mainnet and preview (clusters-side work, in flight) — today only preprod serves v7. Deploying this first would let users create v7 ports on networks that don't serve them.

## Verification

- `cargo test`: 145 passed, 0 failed.
- `python3 -m json.tool` on the edited file: valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)