### PR TITLE
ci: use paths-ignore so pushes to main actually trigger Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ on:
   push:
     branches:
       - "main"
-    paths:
-      - "!test/**"
-      - "!dist-workspace.toml"
+    paths-ignore:
+      - "test/**"
+      - "dist-workspace.toml"
 
 jobs:
   build:


### PR DESCRIPTION
A `paths:` filter containing only negated patterns (`!test/**`) matches nothing — GitHub requires a positive pattern before exclusions apply, and `paths-ignore` is the construct for "everything except". Since this filter landed, pushes to main have not triggered Build, so the chained Deploy also never fired; deploys only happened via manual `workflow_dispatch`.

One consequence right now: the ogmios v7 catalog change (#273) merged without deploying. The rollout is being handled by manual dispatch (intentionally, to sequence after infra); this PR fixes the trigger for future merges.

**Heads-up when merging:** once this lands, this merge itself (and every subsequent merge to main) triggers Build → Deploy automatically. Merge when auto-deploy of main HEAD is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)