### PR TITLE
project: add a ProjectOwnerChanged event to make ownership transferable

### DIFF
--- a/.sqlx/query-03df2ffde3a46daa92116850ab79300cf093b3855653913c6a60cfa34a4fffd2.json
+++ b/.sqlx/query-03df2ffde3a46daa92116850ab79300cf093b3855653913c6a60cfa34a4fffd2.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                UPDATE project_user\n                SET role = $1\n                WHERE project_id = $2 AND user_id = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "03df2ffde3a46daa92116850ab79300cf093b3855653913c6a60cfa34a4fffd2"
+}

--- a/.sqlx/query-6c8d044c774d31a67e9a465f5d6a9df3bef00adc77d6dea143a2adb33c5782bf.json
+++ b/.sqlx/query-6c8d044c774d31a67e9a465f5d6a9df3bef00adc77d6dea143a2adb33c5782bf.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                UPDATE project\n                SET owner = $1, updated_at = $2\n                WHERE id = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "6c8d044c774d31a67e9a465f5d6a9df3bef00adc77d6dea143a2adb33c5782bf"
+}

--- a/examples/config/cli.toml
+++ b/examples/config/cli.toml
@@ -16,3 +16,7 @@ url = "https://txpipe.us.auth0.com"
 client_id=""
 client_secret=""
 audience="https://txpipe.us.auth0.com/api/v2/"
+
+[stripe]
+url = "https://api.stripe.com/v1"
+api_key = ""

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -67,6 +67,21 @@ pub struct RenameProjectArgs {
 }
 
 #[derive(Parser, Clone)]
+pub struct TransferProjectArgs {
+    /// Project id
+    #[arg(short, long)]
+    pub id: String,
+
+    /// Email of the new owner. Must already be a member of the project.
+    #[arg(short, long)]
+    pub new_owner_email: String,
+
+    // Dry run
+    #[arg(short, long, action)]
+    pub dry_run: bool,
+}
+
+#[derive(Parser, Clone)]
 pub struct DeleteProjectArgs {
     /// Project id
     #[arg(short, long)]
@@ -173,6 +188,9 @@ enum Commands {
 
     /// Get projects by user
     RenameProject(RenameProjectArgs),
+
+    /// Transfer a project to another member of the project
+    TransferProject(TransferProjectArgs),
 
     /// Get resource by project namespace
     Resource(ResourceArgs),
@@ -289,6 +307,15 @@ async fn main() -> Result<()> {
             )
             .await?;
         }
+        Commands::TransferProject(args) => {
+            fabric::drivers::backoffice::transfer_project(
+                config.clone().into(),
+                args.id,
+                args.new_owner_email,
+                args.dry_run,
+            )
+            .await?;
+        }
         Commands::DeleteProject(args) => {
             fabric::drivers::backoffice::delete_project(
                 config.clone().into(),
@@ -337,6 +364,11 @@ struct AuthConfig {
     audience: String,
 }
 #[derive(Debug, Clone, Deserialize)]
+struct StripeConfig {
+    url: String,
+    api_key: String,
+}
+#[derive(Debug, Clone, Deserialize)]
 struct Config {
     db_path: String,
     topic_events: String,
@@ -344,6 +376,8 @@ struct Config {
     kafka_consumer: HashMap<String, String>,
     kafka_producer: HashMap<String, String>,
     auth: AuthConfig,
+    /// Only required by `transfer-project`; every other subcommand works without it.
+    stripe: Option<StripeConfig>,
     crds_path: PathBuf,
 }
 impl Config {
@@ -366,6 +400,8 @@ impl From<Config> for BackofficeConfig {
             auth_client_id: value.auth.client_id,
             auth_client_secret: value.auth.client_secret,
             auth_audience: value.auth.audience,
+            stripe_url: value.stripe.as_ref().map(|s| s.url.clone()),
+            stripe_api_key: value.stripe.as_ref().map(|s| s.api_key.clone()),
             topic_events: value.topic_events,
             kafka_producer: value.kafka_producer,
         }

--- a/src/domain/event/mod.rs
+++ b/src/domain/event/mod.rs
@@ -51,6 +51,17 @@ pub struct ProjectDeleted {
 into_event!(ProjectDeleted);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectOwnerChanged {
+    pub id: String,
+    pub project_id: String,
+    pub previous_owner: String,
+    pub new_owner: String,
+    pub changed_by: String,
+    pub changed_at: DateTime<Utc>,
+}
+into_event!(ProjectOwnerChanged);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectSecretCreated {
     pub id: String,
     pub project_id: String,
@@ -180,6 +191,7 @@ pub enum Event {
     ProjectCreated(ProjectCreated),
     ProjectUpdated(ProjectUpdated),
     ProjectDeleted(ProjectDeleted),
+    ProjectOwnerChanged(ProjectOwnerChanged),
     ProjectSecretCreated(ProjectSecretCreated),
     ProjectSecretDeleted(ProjectSecretDeleted),
     ProjectUserInviteCreated(ProjectUserInviteCreated),
@@ -197,6 +209,7 @@ impl Event {
             Event::ProjectCreated(_) => "ProjectCreated".into(),
             Event::ProjectUpdated(_) => "ProjectUpdated".into(),
             Event::ProjectDeleted(_) => "ProjectDeleted".into(),
+            Event::ProjectOwnerChanged(_) => "ProjectOwnerChanged".into(),
             Event::ProjectSecretCreated(_) => "ProjectSecretCreated".into(),
             Event::ProjectSecretDeleted(_) => "ProjectSecretDeleted".into(),
             Event::ProjectUserInviteCreated(_) => "ProjectUserInviteCreated".into(),
@@ -214,6 +227,9 @@ impl Event {
             "ProjectCreated" => Ok(Self::ProjectCreated(serde_json::from_slice(payload)?)),
             "ProjectUpdated" => Ok(Self::ProjectUpdated(serde_json::from_slice(payload)?)),
             "ProjectDeleted" => Ok(Self::ProjectDeleted(serde_json::from_slice(payload)?)),
+            "ProjectOwnerChanged" => {
+                Ok(Self::ProjectOwnerChanged(serde_json::from_slice(payload)?))
+            }
             "ProjectSecretCreated" => {
                 Ok(Self::ProjectSecretCreated(serde_json::from_slice(payload)?))
             }
@@ -275,6 +291,18 @@ mod tests {
                 billing_subscription_id: None,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+            }
+        }
+    }
+    impl Default for ProjectOwnerChanged {
+        fn default() -> Self {
+            Self {
+                id: Uuid::new_v4().to_string(),
+                project_id: Uuid::new_v4().to_string(),
+                previous_owner: "user id".into(),
+                new_owner: "new user id".into(),
+                changed_by: "user id".into(),
+                changed_at: Utc::now(),
             }
         }
     }

--- a/src/domain/project/cache.rs
+++ b/src/domain/project/cache.rs
@@ -2,14 +2,15 @@ use chrono::{DateTime, Utc};
 use std::sync::Arc;
 
 use crate::domain::event::{
-    ProjectCreated, ProjectDeleted, ProjectSecretCreated, ProjectSecretDeleted, ProjectUpdated,
-    ProjectUserDeleted, ProjectUserInviteAccepted, ProjectUserInviteCreated,
-    ProjectUserInviteDeleted,
+    ProjectCreated, ProjectDeleted, ProjectOwnerChanged, ProjectSecretCreated,
+    ProjectSecretDeleted, ProjectUpdated, ProjectUserDeleted, ProjectUserInviteAccepted,
+    ProjectUserInviteCreated, ProjectUserInviteDeleted,
 };
 use crate::domain::Result;
 
 use super::{
-    Project, ProjectSecret, ProjectUpdate, ProjectUser, ProjectUserInvite, ProjectUserProject,
+    Project, ProjectOwnerChange, ProjectSecret, ProjectUpdate, ProjectUser, ProjectUserInvite,
+    ProjectUserProject,
 };
 
 #[cfg_attr(test, mockall::automock)]
@@ -20,6 +21,7 @@ pub trait ProjectDrivenCache: Send + Sync {
     async fn find_by_id(&self, id: &str) -> Result<Option<Project>>;
     async fn create(&self, project: &Project) -> Result<()>;
     async fn update(&self, project: &ProjectUpdate) -> Result<()>;
+    async fn change_owner(&self, change: &ProjectOwnerChange) -> Result<()>;
     async fn delete(&self, id: &str, deleted_at: &DateTime<Utc>) -> Result<()>;
     async fn create_secret(&self, secret: &ProjectSecret) -> Result<()>;
     async fn find_secrets(&self, project: &str) -> Result<Vec<ProjectSecret>>;
@@ -66,6 +68,13 @@ pub async fn create(cache: Arc<dyn ProjectDrivenCache>, evt: ProjectCreated) -> 
 
 pub async fn update(cache: Arc<dyn ProjectDrivenCache>, evt: ProjectUpdated) -> Result<()> {
     cache.update(&evt.try_into()?).await
+}
+
+pub async fn change_owner(
+    cache: Arc<dyn ProjectDrivenCache>,
+    evt: ProjectOwnerChanged,
+) -> Result<()> {
+    cache.change_owner(&evt.into()).await
 }
 
 pub async fn delete(cache: Arc<dyn ProjectDrivenCache>, evt: ProjectDeleted) -> Result<()> {
@@ -127,6 +136,17 @@ mod tests {
         let evt = ProjectCreated::default();
 
         let result = create(Arc::new(cache), evt).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn it_should_change_project_owner_cache() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache.expect_change_owner().return_once(|_| Ok(()));
+
+        let evt = ProjectOwnerChanged::default();
+
+        let result = change_owner(Arc::new(cache), evt).await;
         assert!(result.is_ok());
     }
 

--- a/src/domain/project/command.rs
+++ b/src/domain/project/command.rs
@@ -13,9 +13,9 @@ use crate::domain::{
     auth::{assert_permission, Auth0Driven, Credential, UserId},
     error::Error,
     event::{
-        EventDrivenBridge, ProjectCreated, ProjectDeleted, ProjectSecretCreated,
-        ProjectSecretDeleted, ProjectUpdated, ProjectUserDeleted, ProjectUserInviteAccepted,
-        ProjectUserInviteCreated, ProjectUserInviteDeleted,
+        EventDrivenBridge, ProjectCreated, ProjectDeleted, ProjectOwnerChanged,
+        ProjectSecretCreated, ProjectSecretDeleted, ProjectUpdated, ProjectUserDeleted,
+        ProjectUserInviteAccepted, ProjectUserInviteCreated, ProjectUserInviteDeleted,
     },
     project::{ProjectStatus, ProjectUserAggregated, ProjectUserInviteStatus},
     utils, Result, MAX_SECRET, PAGE_SIZE_DEFAULT, PAGE_SIZE_MAX,
@@ -124,6 +124,118 @@ pub async fn update(
     };
 
     Ok(project)
+}
+
+/// Self-service entry point for an ownership transfer: only the current owner may transfer.
+///
+/// Not yet reachable over gRPC — transfers are run from the backoffice CLI, which calls
+/// `apply_ownership_transfer` directly. This exists so the authorization rule for the self-service
+/// path is settled and tested ahead of the RPC being added.
+#[allow(dead_code)]
+pub async fn transfer_ownership(
+    cache: Arc<dyn ProjectDrivenCache>,
+    event: Arc<dyn EventDrivenBridge>,
+    auth0: Arc<dyn Auth0Driven>,
+    stripe: Arc<dyn StripeDriven>,
+    cmd: TransferOwnershipCmd,
+) -> Result<()> {
+    let user_id = assert_credential(&cmd.credential)?;
+    assert_permission(
+        cache.clone(),
+        &cmd.credential,
+        &cmd.project_id,
+        Some(ProjectUserRole::Owner),
+    )
+    .await?;
+
+    apply_ownership_transfer(
+        cache,
+        event,
+        auth0,
+        stripe,
+        &cmd.project_id,
+        &cmd.new_owner,
+        &user_id,
+        false,
+    )
+    .await
+}
+
+/// Validates and performs an ownership transfer, with no authorization check of its own.
+///
+/// Callers are responsible for authorization: `transfer_ownership` asserts the caller holds the
+/// `Owner` role, while the backoffice driver is already privileged and passes `changed_by` to
+/// record who ran it.
+///
+/// With `dry_run`, every validation still runs but neither the Stripe update nor the event
+/// dispatch happens, so an operator can confirm a transfer is viable before committing to it.
+#[allow(clippy::too_many_arguments)]
+pub async fn apply_ownership_transfer(
+    cache: Arc<dyn ProjectDrivenCache>,
+    event: Arc<dyn EventDrivenBridge>,
+    auth0: Arc<dyn Auth0Driven>,
+    stripe: Arc<dyn StripeDriven>,
+    project_id: &str,
+    new_owner: &str,
+    changed_by: &str,
+    dry_run: bool,
+) -> Result<()> {
+    let Some(project) = cache.find_by_id(project_id).await? else {
+        return Err(Error::CommandMalformed("invalid project id".into()));
+    };
+
+    if project.owner == new_owner {
+        return Err(Error::CommandMalformed(
+            "user already is the project owner".into(),
+        ));
+    }
+
+    if cache
+        .find_user_permission(new_owner, project_id)
+        .await?
+        .is_none()
+    {
+        return Err(Error::CommandMalformed(
+            "new owner is not a member of the project".into(),
+        ));
+    }
+
+    let profile = auth0.find_info(&format!("user_id:{new_owner}")).await?;
+    if profile.is_empty() {
+        return Err(Error::Unexpected("Invalid user_id".into()));
+    }
+    let profile = profile.first().unwrap();
+
+    let evt = ProjectOwnerChanged {
+        id: Uuid::new_v4().to_string(),
+        project_id: project.id,
+        previous_owner: project.owner,
+        new_owner: new_owner.to_string(),
+        changed_by: changed_by.to_string(),
+        changed_at: Utc::now(),
+    };
+
+    if dry_run {
+        info!("event to dispath: {:?}", evt);
+        info!(
+            stripe_customer = &project.billing_provider_id,
+            name = &profile.name,
+            email = &profile.email,
+            "stripe customer to update"
+        );
+        return Ok(());
+    }
+
+    // The stripe call happens here, before dispatching, because projections are replayed in full
+    // whenever the cache is rebuilt. See `create` above for the same pattern.
+    stripe
+        .update_customer(&project.billing_provider_id, &profile.name, &profile.email)
+        .await?;
+
+    event.dispatch(evt.into()).await?;
+    info!(project = project_id, "project owner changed");
+
+    Ok(())
 }
 
 pub async fn delete(
@@ -843,6 +955,13 @@ impl FetchMeUserCmd {
 }
 
 #[derive(Debug, Clone)]
+pub struct TransferOwnershipCmd {
+    pub credential: Credential,
+    pub project_id: String,
+    pub new_owner: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct DeleteUserCmd {
     pub credential: Credential,
     pub project_id: String,
@@ -1117,6 +1236,15 @@ mod tests {
                 credential: Credential::Auth0("user id".into()),
                 id: "member user id".into(),
                 project_id: Uuid::new_v4().to_string(),
+            }
+        }
+    }
+    impl Default for TransferOwnershipCmd {
+        fn default() -> Self {
+            Self {
+                credential: Credential::Auth0("user id".into()),
+                project_id: Uuid::new_v4().to_string(),
+                new_owner: "member user id".into(),
             }
         }
     }
@@ -2056,6 +2184,239 @@ mod tests {
         let result = delete_user(Arc::new(cache), Arc::new(event), cmd).await;
         assert!(result.is_ok());
     }
+
+    #[tokio::test]
+    async fn it_should_transfer_project_ownership() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_user_permission()
+            .times(2)
+            .returning(|_, _| Ok(Some(ProjectUser::default())));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let mut auth0 = MockAuth0Driven::new();
+        auth0
+            .expect_find_info()
+            .return_once(|_| Ok(vec![Auth0Profile::default()]));
+
+        let mut stripe = MockStripeDriven::new();
+        stripe
+            .expect_update_customer()
+            .times(1)
+            .returning(|_, _, _| Ok(()));
+
+        let mut event = MockEventDrivenBridge::new();
+        event.expect_dispatch().times(1).return_once(|_| Ok(()));
+
+        let cmd = TransferOwnershipCmd::default();
+
+        let result = transfer_ownership(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            cmd,
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn it_should_not_dispatch_transfer_ownership_on_dry_run() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_user_permission()
+            .times(1)
+            .returning(|_, _| Ok(Some(ProjectUser::default())));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let mut auth0 = MockAuth0Driven::new();
+        auth0
+            .expect_find_info()
+            .return_once(|_| Ok(vec![Auth0Profile::default()]));
+
+        // Neither mock has an expectation: both panic if called during a dry run.
+        let stripe = MockStripeDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        let result = apply_ownership_transfer(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            "project id",
+            "member user id",
+            "backoffice",
+            true,
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn it_should_fail_transfer_ownership_on_dry_run_when_new_owner_is_not_a_member() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_user_permission()
+            .times(1)
+            .returning(|_, _| Ok(None));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let auth0 = MockAuth0Driven::new();
+        let stripe = MockStripeDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        let result = apply_ownership_transfer(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            "project id",
+            "member user id",
+            "backoffice",
+            true,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::CommandMalformed(_))));
+    }
+    #[tokio::test]
+    async fn it_should_fail_transfer_ownership_when_invalid_permission_member() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache.expect_find_user_permission().return_once(|_, _| {
+            Ok(Some(ProjectUser {
+                role: ProjectUserRole::Member,
+                ..Default::default()
+            }))
+        });
+
+        let auth0 = MockAuth0Driven::new();
+        let stripe = MockStripeDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        let cmd = TransferOwnershipCmd::default();
+
+        let result = transfer_ownership(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            cmd,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::Unauthorized(_))));
+    }
+    #[tokio::test]
+    async fn it_should_fail_transfer_ownership_when_the_user_is_already_the_owner() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_user_permission()
+            .return_once(|_, _| Ok(Some(ProjectUser::default())));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let auth0 = MockAuth0Driven::new();
+        let stripe = MockStripeDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        // Project::default() is owned by "user id".
+        let cmd = TransferOwnershipCmd {
+            new_owner: "user id".into(),
+            ..Default::default()
+        };
+
+        let result = transfer_ownership(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            cmd,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::CommandMalformed(_))));
+    }
+    #[tokio::test]
+    async fn it_should_fail_transfer_ownership_when_new_owner_is_not_a_member() {
+        let mut cache = MockProjectDrivenCache::new();
+        // First call authorizes the caller, second looks up the new owner.
+        cache
+            .expect_find_user_permission()
+            .times(1)
+            .returning(|_, _| Ok(Some(ProjectUser::default())));
+        cache
+            .expect_find_user_permission()
+            .times(1)
+            .returning(|_, _| Ok(None));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let auth0 = MockAuth0Driven::new();
+        let stripe = MockStripeDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        let cmd = TransferOwnershipCmd::default();
+
+        let result = transfer_ownership(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            cmd,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::CommandMalformed(_))));
+    }
+    #[tokio::test]
+    async fn it_should_not_dispatch_transfer_ownership_when_stripe_fails() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_user_permission()
+            .times(2)
+            .returning(|_, _| Ok(Some(ProjectUser::default())));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let mut auth0 = MockAuth0Driven::new();
+        auth0
+            .expect_find_info()
+            .return_once(|_| Ok(vec![Auth0Profile::default()]));
+
+        let mut stripe = MockStripeDriven::new();
+        stripe
+            .expect_update_customer()
+            .returning(|_, _, _| Err(Error::Unexpected("stripe down".into())));
+
+        // No dispatch expectation: the mock panics if the event is dispatched anyway.
+        let event = MockEventDrivenBridge::new();
+
+        let cmd = TransferOwnershipCmd::default();
+
+        let result = transfer_ownership(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            Arc::new(stripe),
+            cmd,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
     #[tokio::test]
     async fn it_should_fail_delete_project_user_when_invalid_permission_member() {
         let mut cache = MockProjectDrivenCache::new();

--- a/src/domain/project/mod.rs
+++ b/src/domain/project/mod.rs
@@ -5,8 +5,8 @@ use chrono::{DateTime, Utc};
 use super::{
     error::Error,
     event::{
-        ProjectCreated, ProjectSecretCreated, ProjectUpdated, ProjectUserInviteAccepted,
-        ProjectUserInviteCreated,
+        ProjectCreated, ProjectOwnerChanged, ProjectSecretCreated, ProjectUpdated,
+        ProjectUserInviteAccepted, ProjectUserInviteCreated,
     },
     Result,
 };
@@ -19,6 +19,7 @@ pub mod command;
 #[async_trait::async_trait]
 pub trait StripeDriven: Send + Sync {
     async fn create_customer(&self, name: &str, email: &str) -> Result<String>;
+    async fn update_customer(&self, customer_id: &str, name: &str, email: &str) -> Result<()>;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -85,6 +86,24 @@ impl TryFrom<ProjectUpdated> for ProjectUpdate {
             },
             updated_at: value.updated_at,
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectOwnerChange {
+    pub project_id: String,
+    pub previous_owner: String,
+    pub new_owner: String,
+    pub changed_at: DateTime<Utc>,
+}
+impl From<ProjectOwnerChanged> for ProjectOwnerChange {
+    fn from(value: ProjectOwnerChanged) -> Self {
+        Self {
+            project_id: value.project_id,
+            previous_owner: value.previous_owner,
+            new_owner: value.new_owner,
+            changed_at: value.changed_at,
+        }
     }
 }
 

--- a/src/driven/cache/project.rs
+++ b/src/driven/cache/project.rs
@@ -6,8 +6,8 @@ use crate::domain::{
     error::Error,
     project::{
         cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice},
-        Project, ProjectSecret, ProjectStatus, ProjectUpdate, ProjectUser, ProjectUserInvite,
-        ProjectUserInviteStatus, ProjectUserProject, ProjectUserRole,
+        Project, ProjectOwnerChange, ProjectSecret, ProjectStatus, ProjectUpdate, ProjectUser,
+        ProjectUserInvite, ProjectUserInviteStatus, ProjectUserProject, ProjectUserRole,
     },
     resource::ResourceStatus,
     Result,
@@ -222,6 +222,55 @@ impl ProjectDrivenCache for SqliteProjectDrivenCache {
             }
             (None, None) => Ok(()),
         }
+    }
+
+    async fn change_owner(&self, change: &ProjectOwnerChange) -> Result<()> {
+        let mut tx = self.sqlite.db.begin().await?;
+
+        sqlx::query!(
+            r#"
+                UPDATE project
+                SET owner = $1, updated_at = $2
+                WHERE id = $3
+            "#,
+            change.new_owner,
+            change.changed_at,
+            change.project_id,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let owner_role = ProjectUserRole::Owner.to_string();
+        sqlx::query!(
+            r#"
+                UPDATE project_user
+                SET role = $1
+                WHERE project_id = $2 AND user_id = $3
+            "#,
+            owner_role,
+            change.project_id,
+            change.new_owner,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let member_role = ProjectUserRole::Member.to_string();
+        sqlx::query!(
+            r#"
+                UPDATE project_user
+                SET role = $1
+                WHERE project_id = $2 AND user_id = $3
+            "#,
+            member_role,
+            change.project_id,
+            change.previous_owner,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(())
     }
 
     async fn delete(&self, id: &str, deleted_at: &DateTime<Utc>) -> Result<()> {
@@ -884,6 +933,97 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn it_should_change_project_owner() {
+        let cache = get_cache().await;
+        let project = Project::default();
+        cache.create(&project).await.unwrap();
+
+        // The new owner must already be a member of the project.
+        let new_owner = ProjectUser {
+            user_id: "new user id".into(),
+            project_id: project.id.clone(),
+            role: ProjectUserRole::Member,
+            created_at: Utc::now(),
+        };
+        cache
+            .create_user_acceptance("invite id", &new_owner)
+            .await
+            .unwrap();
+
+        let change = ProjectOwnerChange {
+            project_id: project.id.clone(),
+            previous_owner: project.owner.clone(),
+            new_owner: new_owner.user_id.clone(),
+            changed_at: Utc::now(),
+        };
+        let result = cache.change_owner(&change).await;
+        assert!(result.is_ok());
+
+        let updated = cache.find_by_id(&project.id).await.unwrap().unwrap();
+        assert_eq!(updated.owner, new_owner.user_id);
+
+        let new_permission = cache
+            .find_user_permission(&new_owner.user_id, &project.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_permission.role, ProjectUserRole::Owner);
+
+        let previous_permission = cache
+            .find_user_permission(&project.owner, &project.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(previous_permission.role, ProjectUserRole::Member);
+    }
+
+    #[tokio::test]
+    async fn it_should_change_project_owner_idempotently() {
+        let cache = get_cache().await;
+        let project = Project::default();
+        cache.create(&project).await.unwrap();
+
+        let new_owner = ProjectUser {
+            user_id: "new user id".into(),
+            project_id: project.id.clone(),
+            role: ProjectUserRole::Member,
+            created_at: Utc::now(),
+        };
+        cache
+            .create_user_acceptance("invite id", &new_owner)
+            .await
+            .unwrap();
+
+        let change = ProjectOwnerChange {
+            project_id: project.id.clone(),
+            previous_owner: project.owner.clone(),
+            new_owner: new_owner.user_id.clone(),
+            changed_at: Utc::now(),
+        };
+
+        // Replaying the same event must converge on the same state.
+        cache.change_owner(&change).await.unwrap();
+        cache.change_owner(&change).await.unwrap();
+
+        let updated = cache.find_by_id(&project.id).await.unwrap().unwrap();
+        assert_eq!(updated.owner, new_owner.user_id);
+
+        let new_permission = cache
+            .find_user_permission(&new_owner.user_id, &project.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_permission.role, ProjectUserRole::Owner);
+
+        let previous_permission = cache
+            .find_user_permission(&project.owner, &project.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(previous_permission.role, ProjectUserRole::Member);
     }
 
     #[tokio::test]

--- a/src/driven/stripe/mod.rs
+++ b/src/driven/stripe/mod.rs
@@ -55,6 +55,33 @@ impl StripeDriven for StripeDrivenImpl {
 
         Ok(customer.id)
     }
+
+    async fn update_customer(&self, customer_id: &str, name: &str, email: &str) -> Result<()> {
+        let mut params = HashMap::new();
+        params.insert("name", name);
+        params.insert("email", email);
+
+        let response = self
+            .client
+            .post(format!("{}/customers/{}", &self.url, customer_id))
+            .basic_auth(&self.api_key, Some(""))
+            .form(&params)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if status.is_client_error() || status.is_server_error() {
+            error!(
+                status = status.to_string(),
+                "request status code fail to update stripe customer"
+            );
+            return Err(Error::Unexpected(format!(
+                "stripe update customer request error. Status: {status}"
+            )));
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         DEFAULT_CATEGORY, auth::{Auth0Driven, Auth0Profile}, event::{
             EventDrivenBridge, ProjectDeleted, ProjectUpdated, ResourceCreated, ResourceDeleted, ResourceUpdated
         }, metadata::{KnownField, MetadataDriven}, project::{
-            ProjectStatus, ProjectUserProject, cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice}
+            self, ProjectStatus, ProjectUserProject, StripeDriven, cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice}
         }, resource::{
             ResourceStatus, cache::{ResourceDrivenCache, ResourceDrivenCacheBackoffice}, cluster::ResourceDrivenClusterBackoffice, command::{build_key, encode_key}
         }, usage::{UsageReport, UsageReportImpl, cache::UsageDrivenCacheBackoffice}, utils::{self, get_schema_from_crd}
@@ -28,6 +28,7 @@ use crate::{
         k8s::K8sCluster,
         kafka::KafkaProducer,
         metadata::FileMetadata,
+        stripe::StripeDrivenImpl,
     },
 };
 
@@ -203,6 +204,66 @@ pub async fn rename_project(
     } else {
         event.dispatch(evt.into()).await?;
         info!(project = &id, "project updated");
+    }
+
+    Ok(())
+}
+
+pub async fn transfer_project(
+    config: BackofficeConfig,
+    id: String,
+    new_owner_email: String,
+    dry_run: bool,
+) -> Result<()> {
+    let sqlite_cache = Arc::new(SqliteCache::new(Path::new(&config.db_path)).await?);
+    sqlite_cache.migrate().await?;
+
+    let cache: Arc<dyn ProjectDrivenCache> =
+        Arc::new(SqliteProjectDrivenCache::new(sqlite_cache.clone()));
+
+    let auth0: Arc<dyn Auth0Driven> = Arc::new(
+        Auth0DrivenImpl::try_new(
+            &config.auth_url,
+            &config.auth_client_id,
+            &config.auth_client_secret,
+            &config.auth_audience,
+        )
+        .await?,
+    );
+
+    let (Some(stripe_url), Some(stripe_api_key)) = (&config.stripe_url, &config.stripe_api_key)
+    else {
+        bail!("a [stripe] section is required in the cli config to transfer a project")
+    };
+
+    let stripe: Arc<dyn StripeDriven> = Arc::new(StripeDrivenImpl::new(stripe_url, stripe_api_key));
+
+    let event = Arc::new(KafkaProducer::new(
+        &config.topic_events,
+        &config.kafka_producer,
+    )?);
+
+    // The CLI takes an email; the domain command takes an auth0 user id.
+    let profile = auth0.find_info(&format!("email:{new_owner_email}")).await?;
+    if profile.is_empty() {
+        bail!("No one user was found")
+    }
+    let profile = profile.first().unwrap();
+
+    project::command::apply_ownership_transfer(
+        cache,
+        event,
+        auth0.clone(),
+        stripe,
+        &id,
+        &profile.user_id,
+        "backoffice",
+        dry_run,
+    )
+    .await?;
+
+    if !dry_run {
+        info!(project = &id, owner = &profile.email, "project transferred");
     }
 
     Ok(())
@@ -976,6 +1037,10 @@ pub struct BackofficeConfig {
     pub auth_client_id: String,
     pub auth_client_secret: String,
     pub auth_audience: String,
+
+    /// Only populated when the config carries a `[stripe]` section; required by `transfer_project`.
+    pub stripe_url: Option<String>,
+    pub stripe_api_key: Option<String>,
 
     pub topic_events: String,
     pub kafka_producer: HashMap<String, String>,

--- a/src/drivers/cache/mod.rs
+++ b/src/drivers/cache/mod.rs
@@ -78,6 +78,9 @@ pub async fn subscribe(config: CacheConfig) -> Result<()> {
                     Event::ProjectDeleted(evt) => {
                         project::cache::delete(project_cache.clone(), evt.clone()).await
                     }
+                    Event::ProjectOwnerChanged(evt) => {
+                        project::cache::change_owner(project_cache.clone(), evt.clone()).await
+                    }
                     Event::ProjectSecretCreated(evt) => {
                         project::cache::create_secret(project_cache.clone(), evt.clone()).await
                     }


### PR DESCRIPTION
## Why

`project.owner` is written once from `ProjectCreated` and never mutated — `ProjectUpdated` only carries `name` and `status`, and the SQLite projection is a hardcoded 2x2 match on those two fields. The `Project` proto message doesn't even expose `owner`.

That leaves the creator as the only user who can ever delete the project (`command.rs:148`), unremovable from it (`command.rs:422`), and permanently attributed as its owner in Slack notifications and backoffice reports.

Note this is distinct from *permissions*: `assert_permission` reads `project_user.role`, never `project.owner`, so inviting someone with `role: "owner"` already grants owner permissions today. This PR makes the `project.owner` record itself transferable and keeps the Stripe customer in sync with it.

## What

A dedicated `ProjectOwnerChanged` event, plus a backoffice CLI command:

```
cli transfer-project --id <id> --new-owner-email <email> [--dry-run]
```

The new owner must already be a member of the project; the previous owner is demoted to `member`.

### Design notes

**A new event rather than extending `ProjectUpdated`.** Serde doesn't reject unknown fields anywhere in this codebase — the producer already injects an `annotation` field that exists in no struct. So an old daemon receiving a `ProjectUpdated` carrying a new `owner` field would silently apply only name/status, log `"Succesfully handled event"`, and commit. A partial write reported as success is much harder to spot than a distinct `"Event key not implemented"` error.

**The projection is pure SQL and idempotent.** One transaction, three `UPDATE`s: set `project.owner`, promote the new owner to `owner`, demote the previous owner to `member`. Replaying converges, which matters because the cache is rebuilt from `earliest` whenever the consumer group is bumped.

**The Stripe call lives in the command, before dispatch.** This mirrors `command::create`, which calls `create_customer` before dispatching `ProjectCreated`. Putting it in the projection would re-fire the API call on every cache rebuild.

**One implementation, two entry points.** `apply_ownership_transfer` holds the validation and effects; `transfer_ownership` adds the owner-only authorization check and is the seam for a future self-service RPC. The CLI calls the former, so the validation rules can't drift between the two paths.

**`--dry-run` genuinely validates** — it runs every check and skips only the Stripe call and the dispatch.

**`[stripe]` in the CLI config is optional**, so the other subcommands (including the billing cron) keep working for operators whose `cli.toml` lacks the section. `transfer-project` bails with a clear message if it's missing.

## ⚠️ Rollout order matters

An old consumer receiving an unknown event key does **not** crash — but it logs the conversion failure and **commits the offset**, skipping the message permanently for that consumer group.

The consumer that matters is the **RPC**: `src/bin/rpc.rs:38` runs `drivers::cache::subscribe` alongside the gRPC server, and that cache is what `assert_permission` reads (`project_user.role`) and what the project-delete guard reads (`project.owner`).

| Consumer | Reads `owner` / `project_user`? | Needs the event |
|---|---|---|
| **RPC** cache | Yes — `assert_permission`, delete guard | **Yes — deploy before the first transfer** |
| Daemon cache (Usage/Full) | No — usage joins `project` on id/namespace/billing only | No |
| Daemon monitor | No — `owner` is never projected to k8s; has a catch-all arm | No |
| Backoffice CLI `sync` | Yes — `fetch_projects`, `find_new_users` | Same binary you run `transfer-project` from |

1. Deploy the new **RPC** first.
2. Only then run the CLI. It's a separate binary talking straight to Kafka, so it's easy to run against a stale cluster.
3. If the order gets inverted: bump that consumer's `group.id` and replay from `earliest`.

The daemon's cache is a separate projection into a separate volume and only feeds the usage scheduler, so skipping the event is functionally harmless there today. Worth noting it stays permanently divergent on `project.owner` / `project_user.role` for skipped events, which is a silent trap if anything later starts reading those columns from that DB — rolling the daemon too is cheap insurance, just not a blocker.

## Testing

`cargo test` — **155 passed, 0 failed**. 10 new tests:

- happy path, non-member rejection, already-owner rejection, unauthorized-member rejection
- no dispatch when Stripe fails
- both dry-run paths (validates, doesn't dispatch)
- real-SQLite projection tests asserting the role flip and an idempotent double-apply

`.sqlx` offline data regenerated; offline build (`SQLX_OFFLINE=true`) verified.

## Not in scope

- No self-service RPC — transfers are operator-run. Adding one needs a `demeter-run/specs` change, a grpc handler, and console UI.
- The `Project` proto message still doesn't expose `owner`, so the console can't display it.
- The backoffice `find_new_users` query joins on `p.owner == pu.user_id`; transferred projects will behave differently in that report.
- CI clippy currently fails on 5 pre-existing errors in `driven/k8s/mod.rs`, `worker/storage/command.rs`, and `grpc/middlewares/auth.rs` — untouched by this PR, appears to be a toolchain version drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
