### PR TITLE
project: let transfer-project leave the stripe customer alone

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -76,6 +76,11 @@ pub struct TransferProjectArgs {
     #[arg(short, long)]
     pub new_owner_email: String,
 
+    /// Leave the Stripe customer untouched. Use when the billing contact was set deliberately
+    /// rather than tracking the project owner, since the update overwrites name and email.
+    #[arg(short, long, action)]
+    pub skip_stripe: bool,
+
     // Dry run
     #[arg(short, long, action)]
     pub dry_run: bool,
@@ -313,6 +318,7 @@ async fn main() -> Result<()> {
                 args.id,
                 args.new_owner_email,
                 args.dry_run,
+                args.skip_stripe,
             )
             .await?;
         }

--- a/src/domain/project/command.rs
+++ b/src/domain/project/command.rs
@@ -152,7 +152,7 @@ pub async fn transfer_ownership(
         cache,
         event,
         auth0,
-        stripe,
+        Some(stripe),
         &cmd.project_id,
         &cmd.new_owner,
         &user_id,
@@ -169,12 +169,17 @@ pub async fn transfer_ownership(
 ///
 /// With `dry_run`, every validation still runs but neither the Stripe update nor the event
 /// dispatch happens, so an operator can confirm a transfer is viable before committing to it.
+///
+/// `stripe` is `None` when the caller wants the billing contact left alone. The customer's `name`
+/// and `email` are overwritten wholesale when it is `Some`, which destroys a billing address that
+/// was curated rather than tracking the owner — so an operator who knows that is the case passes
+/// `None`. `billing_provider_id` is never touched either way, so billing continuity is unaffected.
 #[allow(clippy::too_many_arguments)]
 pub async fn apply_ownership_transfer(
     cache: Arc<dyn ProjectDrivenCache>,
     event: Arc<dyn EventDrivenBridge>,
     auth0: Arc<dyn Auth0Driven>,
-    stripe: Arc<dyn StripeDriven>,
+    stripe: Option<Arc<dyn StripeDriven>>,
     project_id: &str,
     new_owner: &str,
     changed_by: &str,
@@ -217,20 +222,34 @@ pub async fn apply_ownership_transfer(
 
     if dry_run {
         info!("event to dispath: {:?}", evt);
-        info!(
-            stripe_customer = &project.billing_provider_id,
-            name = &profile.name,
-            email = &profile.email,
-            "stripe customer to update"
-        );
+        match &stripe {
+            Some(_) => info!(
+                stripe_customer = &project.billing_provider_id,
+                name = &profile.name,
+                email = &profile.email,
+                "stripe customer to update"
+            ),
+            None => info!(
+                stripe_customer = &project.billing_provider_id,
+                "stripe customer left unchanged"
+            ),
+        }
         return Ok(());
     }
 
     // The stripe call happens here, before dispatching, because projections are replayed in full
     // whenever the cache is rebuilt. See `create` above for the same pattern.
-    stripe
-        .update_customer(&project.billing_provider_id, &profile.name, &profile.email)
-        .await?;
+    match &stripe {
+        Some(stripe) => {
+            stripe
+                .update_customer(&project.billing_provider_id, &profile.name, &profile.email)
+                .await?
+        }
+        None => info!(
+            stripe_customer = &project.billing_provider_id,
+            "stripe customer left unchanged"
+        ),
+    }
 
     event.dispatch(evt.into()).await?;
     info!(project = project_id, "project owner changed");
@@ -2246,11 +2265,44 @@ mod tests {
             Arc::new(cache),
             Arc::new(event),
             Arc::new(auth0),
-            Arc::new(stripe),
+            Some(Arc::new(stripe)),
             "project id",
             "member user id",
             "backoffice",
             true,
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn it_should_transfer_ownership_without_touching_stripe_when_stripe_is_none() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_user_permission()
+            .times(1)
+            .returning(|_, _| Ok(Some(ProjectUser::default())));
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let mut auth0 = MockAuth0Driven::new();
+        auth0
+            .expect_find_info()
+            .return_once(|_| Ok(vec![Auth0Profile::default()]));
+
+        // The event must still be dispatched — only the billing contact is left alone.
+        let mut event = MockEventDrivenBridge::new();
+        event.expect_dispatch().times(1).return_once(|_| Ok(()));
+
+        let result = apply_ownership_transfer(
+            Arc::new(cache),
+            Arc::new(event),
+            Arc::new(auth0),
+            None,
+            "project id",
+            "member user id",
+            "backoffice",
+            false,
         )
         .await;
         assert!(result.is_ok());
@@ -2274,7 +2326,7 @@ mod tests {
             Arc::new(cache),
             Arc::new(event),
             Arc::new(auth0),
-            Arc::new(stripe),
+            Some(Arc::new(stripe)),
             "project id",
             "member user id",
             "backoffice",

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -214,6 +214,7 @@ pub async fn transfer_project(
     id: String,
     new_owner_email: String,
     dry_run: bool,
+    skip_stripe: bool,
 ) -> Result<()> {
     let sqlite_cache = Arc::new(SqliteCache::new(Path::new(&config.db_path)).await?);
     sqlite_cache.migrate().await?;
@@ -231,12 +232,18 @@ pub async fn transfer_project(
         .await?,
     );
 
-    let (Some(stripe_url), Some(stripe_api_key)) = (&config.stripe_url, &config.stripe_api_key)
-    else {
-        bail!("a [stripe] section is required in the cli config to transfer a project")
-    };
+    // With --skip-stripe the billing contact is left alone, so the config section is not needed.
+    let stripe: Option<Arc<dyn StripeDriven>> = if skip_stripe {
+        info!("--skip-stripe: the stripe customer will not be modified");
+        None
+    } else {
+        let (Some(stripe_url), Some(stripe_api_key)) = (&config.stripe_url, &config.stripe_api_key)
+        else {
+            bail!("a [stripe] section is required in the cli config to transfer a project (or pass --skip-stripe to leave the billing contact unchanged)")
+        };
 
-    let stripe: Arc<dyn StripeDriven> = Arc::new(StripeDrivenImpl::new(stripe_url, stripe_api_key));
+        Some(Arc::new(StripeDrivenImpl::new(stripe_url, stripe_api_key)))
+    };
 
     let event = Arc::new(KafkaProducer::new(
         &config.topic_events,


### PR DESCRIPTION
## Why

`transfer-project` (#275) overwrites the Stripe customer's `name` and `email` with the new owner's Auth0 profile, unconditionally. That's correct when the billing contact is *tracking* the project owner — which is how fabric creates it, from the creator's profile — but wrong once a customer has curated it.

This turned up on a real customer while rehearsing a transfer. Their Stripe customer's billing email was a shared `info@` inbox on a **different domain** from any project member — a value not derivable from any Auth0 profile, so it had been set deliberately. Executing the transfer would have:

- redirected invoices, receipts, payment-failure and dunning mail from the org's billing inbox to a single engineer, and
- destroyed the original with no way back: transferring ownership back writes the *previous owner's* Auth0 address, it does not restore what was there.

Blast radius was never billing continuity — `billing_provider_id` is untouched, so the same customer is still charged on the same subscription. It's who receives billing correspondence, and the customer's display name.

## What

`--skip-stripe` (`-s`) on `transfer-project`. **Default off, so existing behaviour is unchanged.**

```sh
cli transfer-project --id <id> --new-owner-email <email> --skip-stripe --dry-run
```

Implementation notes:

- `apply_ownership_transfer` now takes `Option<Arc<dyn StripeDriven>>` instead of gaining a ninth boolean argument. `None` is the skip, and it makes the "no Stripe driver required" case honest rather than passing a driver that's never called. `transfer_ownership` — the not-yet-wired RPC seam — passes `Some(stripe)`, so the self-service path is unaffected.
- The `[stripe]` config guard moved inside the branch that needs it, so the flag works on a config with **no `[stripe]` section at all**, and its error message now points at the flag.
- The dry run distinguishes `stripe customer to update` from `stripe customer left unchanged`. A rehearsal that doesn't say which one you're getting isn't much of a rehearsal.

## Considered and rejected

Gating the update on whether the current Stripe email *matches the previous owner's* — i.e. infer "this contact is tracking the owner" and only then overwrite. It's a better rule in the abstract and needs no operator judgement, but it requires a new `StripeDriven` read method, a second Auth0 lookup for the previous owner, per-field comparison (a customer can have a tracking email but a curated name), case normalisation, and a defined behaviour when the previous owner's Auth0 profile is gone. Too much machinery for the problem; the flag covers the case that actually occurs.

## Testing

`cargo test` — **156 passed, 0 failed** (+1). The new test covers the real, non-dry-run skip path and asserts the event **still dispatches** — the flag must skip Stripe without skipping the transfer.

Verified end-to-end against a live project with `--skip-stripe --dry-run`:

```
--skip-stripe: the stripe customer will not be modified
event to dispath: ProjectOwnerChanged { previous_owner: "google-oauth2|…", new_owner: "google-oauth2|…", changed_by: "backoffice", … }
stripe customer left unchanged stripe_customer="cus_…"
```

## Follow-up (not in this PR)

The backoffice bounded context documents this command surface and will need updating once the `solution/fabric/repo` gitlink advances: `contracts/fabric-cli.md` lists `transfer-project`'s arguments, and `skills/run-fabric-cli/SKILL.md` states it aborts without `[stripe]` — now true only without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)