### PR TITLE
cli: add project-users, listing a project's members and their roles

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -67,6 +67,17 @@ pub struct RenameProjectArgs {
 }
 
 #[derive(Parser, Clone)]
+pub struct ProjectUsersArgs {
+    /// Project id
+    #[arg(short, long)]
+    pub id: String,
+
+    /// table(log in terminal), csv(save a file project-users.csv)
+    #[arg(short, long)]
+    pub output: Option<String>,
+}
+
+#[derive(Parser, Clone)]
 pub struct TransferProjectArgs {
     /// Project id
     #[arg(short, long)]
@@ -191,6 +202,9 @@ enum Commands {
     /// Get projects by user
     Project(ProjectArgs),
 
+    /// List the users of a project with their roles
+    ProjectUsers(ProjectUsersArgs),
+
     /// Get projects by user
     RenameProject(RenameProjectArgs),
 
@@ -309,6 +323,23 @@ async fn main() -> Result<()> {
                 args.id,
                 args.new_name,
                 args.dry_run,
+            )
+            .await?;
+        }
+        Commands::ProjectUsers(args) => {
+            let output = match args.output {
+                Some(output) => match output.as_str() {
+                    "table" => OutputFormat::Table,
+                    "csv" => OutputFormat::Csv,
+                    _ => bail!("invalid output format"),
+                },
+                None => OutputFormat::Table,
+            };
+
+            fabric::drivers::backoffice::fetch_project_users(
+                config.clone().into(),
+                args.id,
+                output,
             )
             .await?;
         }

--- a/src/domain/project/command.rs
+++ b/src/domain/project/command.rs
@@ -462,9 +462,27 @@ pub async fn fetch_user(
     )
     .await?;
 
-    let project_users = cache
-        .find_users(&cmd.project_id, &cmd.page, &cmd.page_size)
-        .await?;
+    list_users(cache, auth0, &cmd.project_id, &cmd.page, &cmd.page_size).await
+}
+
+/// Lists a project's users with their roles, enriched with their Auth0 profiles.
+///
+/// No authorization check of its own — `fetch_user` asserts the caller holds the `Owner` role
+/// before delegating here, and the backoffice driver is already privileged.
+pub async fn list_users(
+    cache: Arc<dyn ProjectDrivenCache>,
+    auth0: Arc<dyn Auth0Driven>,
+    project_id: &str,
+    page: &u32,
+    page_size: &u32,
+) -> Result<Vec<ProjectUserAggregated>> {
+    let project_users = cache.find_users(project_id, page, page_size).await?;
+
+    // An empty page would otherwise build an empty Auth0 query, which is not a search for nothing
+    // — it returns every user in the tenant.
+    if project_users.is_empty() {
+        return Ok(Vec::new());
+    }
 
     let ids: Vec<String> = project_users
         .iter()
@@ -2163,6 +2181,35 @@ mod tests {
 
         let result = fetch_user(Arc::new(cache), Arc::new(auth0), cmd).await;
         assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn it_should_list_project_users() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_users()
+            .return_once(|_, _, _| Ok(vec![ProjectUser::default()]));
+
+        let mut auth0 = MockAuth0Driven::new();
+        auth0
+            .expect_find_info()
+            .return_once(|_| Ok(vec![Auth0Profile::default()]));
+
+        let result = list_users(Arc::new(cache), Arc::new(auth0), "project id", &1, &12).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+    #[tokio::test]
+    async fn it_should_not_query_auth0_when_the_page_has_no_users() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache.expect_find_users().return_once(|_, _, _| Ok(vec![]));
+
+        // No expectation: an empty page must not reach Auth0 at all. An empty `q` is not a search
+        // for nothing — it matches every user in the tenant.
+        let auth0 = MockAuth0Driven::new();
+
+        let result = list_users(Arc::new(cache), Arc::new(auth0), "project id", &9, &12).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
     }
     #[tokio::test]
     async fn it_should_fail_fetch_project_users_when_invalid_permission_member() {

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -12,10 +12,10 @@ use tracing::{error, info};
 
 use crate::{
     domain::{
-        DEFAULT_CATEGORY, auth::{Auth0Driven, Auth0Profile}, event::{
+        DEFAULT_CATEGORY, PAGE_SIZE_MAX, auth::{Auth0Driven, Auth0Profile}, event::{
             EventDrivenBridge, ProjectDeleted, ProjectUpdated, ResourceCreated, ResourceDeleted, ResourceUpdated
         }, metadata::{KnownField, MetadataDriven}, project::{
-            self, ProjectStatus, ProjectUserProject, StripeDriven, cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice}
+            self, ProjectStatus, ProjectUserAggregated, ProjectUserProject, StripeDriven, cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice}
         }, resource::{
             ResourceStatus, cache::{ResourceDrivenCache, ResourceDrivenCacheBackoffice}, cluster::ResourceDrivenClusterBackoffice, command::{build_key, encode_key}
         }, usage::{UsageReport, UsageReportImpl, cache::UsageDrivenCacheBackoffice}, utils::{self, get_schema_from_crd}
@@ -205,6 +205,65 @@ pub async fn rename_project(
         event.dispatch(evt.into()).await?;
         info!(project = &id, "project updated");
     }
+
+    Ok(())
+}
+
+pub async fn fetch_project_users(
+    config: BackofficeConfig,
+    project_id: String,
+    output: OutputFormat,
+) -> Result<()> {
+    let sqlite_cache = Arc::new(SqliteCache::new(Path::new(&config.db_path)).await?);
+    sqlite_cache.migrate().await?;
+
+    let cache: Arc<dyn ProjectDrivenCache> =
+        Arc::new(SqliteProjectDrivenCache::new(sqlite_cache.clone()));
+
+    let auth0: Arc<dyn Auth0Driven> = Arc::new(
+        Auth0DrivenImpl::try_new(
+            &config.auth_url,
+            &config.auth_client_id,
+            &config.auth_client_secret,
+            &config.auth_audience,
+        )
+        .await?,
+    );
+
+    if cache.find_by_id(&project_id).await?.is_none() {
+        bail!("Failed to locate project")
+    };
+
+    // Page to the end rather than taking the first page: this is the whole membership or it is
+    // misleading, and a caller cannot tell a short list from a truncated one.
+    let mut project_users = Vec::new();
+    let mut page = 1;
+    loop {
+        let batch = project::command::list_users(
+            cache.clone(),
+            auth0.clone(),
+            &project_id,
+            &page,
+            &PAGE_SIZE_MAX,
+        )
+        .await?;
+        let is_last = (batch.len() as u32) < PAGE_SIZE_MAX;
+        project_users.extend(batch);
+        if is_last {
+            break;
+        }
+        page += 1;
+    }
+
+    if project_users.is_empty() {
+        bail!("No one user was found")
+    }
+
+    match output {
+        OutputFormat::Table => output_table_project_users(project_users),
+        OutputFormat::Csv => output_csv_project_users(project_users),
+        OutputFormat::Json => todo!("not implemented"),
+    };
 
     Ok(())
 }
@@ -925,6 +984,63 @@ fn output_csv_diff(report: Vec<(String, (bool, bool))>) {
     }
 
     println!("File {path} created")
+}
+
+fn output_table_project_users(project_users: Vec<ProjectUserAggregated>) {
+    let mut table = Table::new();
+    table.set_header(vec!["", "id", "name", "email", "role", "createdAt"]);
+
+    for (i, u) in project_users.iter().enumerate() {
+        table.add_row(vec![
+            &(i + 1).to_string(),
+            &u.user_id,
+            &u.name,
+            &u.email,
+            &u.role.to_string(),
+            &u.created_at.to_rfc3339(),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+fn output_csv_project_users(project_users: Vec<ProjectUserAggregated>) {
+    let path = "project-users.csv";
+    let result = csv::Writer::from_path(path);
+    if let Err(error) = result {
+        error!(?error);
+        return;
+    }
+
+    let mut wtr = result.unwrap();
+
+    let result = wtr.write_record(["", "id", "name", "email", "role", "createdAt"]);
+    if let Err(error) = result {
+        error!(?error);
+        return;
+    }
+
+    for (i, u) in project_users.iter().enumerate() {
+        let result = wtr.write_record([
+            &(i + 1).to_string(),
+            &u.user_id,
+            &u.name,
+            &u.email,
+            &u.role.to_string(),
+            &u.created_at.to_rfc3339(),
+        ]);
+        if let Err(error) = result {
+            error!(?error);
+            return;
+        }
+    }
+
+    if let Err(error) = wtr.flush() {
+        error!(?error);
+        return;
+    }
+
+    info!("File {} created", path)
 }
 
 fn output_table_new_users(project_users: Vec<ProjectUserProject>, profiles: Vec<Auth0Profile>) {


### PR DESCRIPTION
## Why

There was no way to see who is on a project. The twelve subcommands could tell you which projects a *user* belongs to (`project --email`), but not which users belong to a *project*.

Working around that meant enumerating candidate addresses out of Auth0 with wildcard-plus-exclusion queries and testing each one for membership. That approach has two holes: it only finds members whose email domain you already guessed, so the result is a lower bound rather than a list, and it never reveals a **role** — `project --email` proves a `project_user` row exists, not what's in it.

The gap cost three answers in a single operating session:

- confirming a transfer target was already a member (a precondition of `transfer-project`)
- confirming the previous owner was demoted to `member` rather than removed, after a real transfer
- answering "who are this project's members" at all

All three are things an operator should be able to observe directly. All three were reduced to inference from the code's behaviour.

## What

```sh
cli project-users --id <project-id>                # table
cli project-users --id <project-id> --output csv   # writes ./project-users.csv
```

Output is user id, name, email, role, and joined-at:

```
| # | id                                  | name            | email                 | role   | createdAt        |
| 1 | auth0|6630edc7…                     | someone@…       | someone@…             | owner  | 2024-04-30T…     |
| 2 | google-oauth2|1048355…              | Some Name       | someone.else@…        | member | 2024-11-01T…     |
```

## Implementation

The machinery already existed and was simply never wired to the CLI. `ProjectDrivenCache::find_users` plus the Auth0 enrichment inside `fetch_user` already produce exactly this table — it's exposed over gRPC as `FetchProjectUsers`.

So `fetch_user` now delegates to a new `list_users` that carries no authorization of its own, and the backoffice driver calls that directly. This is the same split introduced for `transfer_ownership` / `apply_ownership_transfer`: the authenticated entry point asserts the role, the shared core does the work, and the privileged backoffice driver reuses the core. No new domain logic, no migration.

Two details worth calling out:

- **The driver pages to the end** rather than returning the first page. A membership list is the whole membership or it's misleading — a caller cannot distinguish a short list from a truncated one, and silently truncating this particular answer is how you conclude someone isn't on a project when they are.
- **`list_users` returns early on an empty page.** The Auth0 query is built by joining user ids with `" OR "`, so an empty page produced an empty `q` — which is not a search for nothing, it matches **every user in the tenant**. Unreachable from `fetch_user` in practice, but reachable the moment anything pages, which this driver does. Fixed and pinned with a test that asserts Auth0 is never called.

Output is `table|csv` rather than `table|json|csv`, following `diff` — the existing `json` arms are `todo!()`, and adding a new command whose documented flag panics seemed worse than omitting it.

## Testing

`cargo test` — **158 passed, 0 failed** (+2): one covering the happy path, one asserting an empty page does not reach Auth0.

Verified against a real project in the backoffice cache: returns 5 members with roles, and independently confirms an earlier wildcard probe of the same project was complete — same five, no members hiding on other domains.

## Follow-up (not in this PR)

The backoffice bounded context documents this surface and will need updating when the `solution/fabric/repo` gitlink advances: `contracts/fabric-cli.md` (subcommand table — now thirteen, not twelve; the credentials matrix, since this needs Auth0; and the pin), and `skills/run-fabric-cli/SKILL.md` under *Inspect*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)