### PR TITLE
feat(cli): add invite-user, inviting a member without owner credentials

### DIFF
--- a/examples/config/cli.toml
+++ b/examples/config/cli.toml
@@ -20,3 +20,10 @@ audience="https://txpipe.us.auth0.com/api/v2/"
 [stripe]
 url = "https://api.stripe.com/v1"
 api_key = ""
+
+# Only needed by invite-user
+[email]
+ses_access_key_id = "xxx"
+ses_secret_access_key = "xxx"
+ses_region = "us-west-2"
+ses_verified_email = "no-reply@demeter.run"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -78,6 +78,29 @@ pub struct ProjectUsersArgs {
 }
 
 #[derive(Parser, Clone)]
+pub struct InviteUserArgs {
+    /// Project id
+    #[arg(short, long)]
+    pub id: String,
+
+    /// Email to invite. The invitee must sign in with this exact address to accept.
+    #[arg(short, long)]
+    pub email: String,
+
+    /// Role to grant on acceptance: owner or member
+    #[arg(short, long, default_value = "member")]
+    pub role: String,
+
+    /// Minutes the invite code stays valid
+    #[arg(short, long, default_value_t = 15)]
+    pub ttl_min: u64,
+
+    // Dry run
+    #[arg(short, long, action)]
+    pub dry_run: bool,
+}
+
+#[derive(Parser, Clone)]
 pub struct TransferProjectArgs {
     /// Project id
     #[arg(short, long)]
@@ -207,6 +230,9 @@ enum Commands {
 
     /// Get projects by user
     RenameProject(RenameProjectArgs),
+
+    /// Invite a user to a project by email
+    InviteUser(InviteUserArgs),
 
     /// Transfer a project to another member of the project
     TransferProject(TransferProjectArgs),
@@ -343,6 +369,17 @@ async fn main() -> Result<()> {
             )
             .await?;
         }
+        Commands::InviteUser(args) => {
+            fabric::drivers::backoffice::invite_user(
+                config.clone().into(),
+                args.id,
+                args.email,
+                args.role,
+                args.ttl_min,
+                args.dry_run,
+            )
+            .await?;
+        }
         Commands::TransferProject(args) => {
             fabric::drivers::backoffice::transfer_project(
                 config.clone().into(),
@@ -406,6 +443,13 @@ struct StripeConfig {
     api_key: String,
 }
 #[derive(Debug, Clone, Deserialize)]
+struct EmailConfig {
+    ses_access_key_id: String,
+    ses_secret_access_key: String,
+    ses_region: String,
+    ses_verified_email: String,
+}
+#[derive(Debug, Clone, Deserialize)]
 struct Config {
     db_path: String,
     topic_events: String,
@@ -415,6 +459,8 @@ struct Config {
     auth: AuthConfig,
     /// Only required by `transfer-project`; every other subcommand works without it.
     stripe: Option<StripeConfig>,
+    /// Only required by `invite-user`; every other subcommand works without it.
+    email: Option<EmailConfig>,
     crds_path: PathBuf,
 }
 impl Config {
@@ -439,6 +485,13 @@ impl From<Config> for BackofficeConfig {
             auth_audience: value.auth.audience,
             stripe_url: value.stripe.as_ref().map(|s| s.url.clone()),
             stripe_api_key: value.stripe.as_ref().map(|s| s.api_key.clone()),
+            ses_access_key_id: value.email.as_ref().map(|e| e.ses_access_key_id.clone()),
+            ses_secret_access_key: value
+                .email
+                .as_ref()
+                .map(|e| e.ses_secret_access_key.clone()),
+            ses_region: value.email.as_ref().map(|e| e.ses_region.clone()),
+            ses_verified_email: value.email.as_ref().map(|e| e.ses_verified_email.clone()),
             topic_events: value.topic_events,
             kafka_producer: value.kafka_producer,
         }

--- a/src/domain/project/command.rs
+++ b/src/domain/project/command.rs
@@ -638,17 +638,49 @@ pub async fn create_user_invite(
     .await
 }
 
-/// Creates and sends a project invite, with no authorization check of its own.
+/// Creates and sends a project invite on behalf of an operator, with no `Owner` check.
 ///
-/// Callers are responsible for authorization: `create_user_invite` asserts the caller holds the
-/// `Owner` role, while the backoffice driver is already privileged. Mirrors the split between
-/// `transfer_ownership` and `apply_ownership_transfer`.
+/// The sibling of `create_user_invite` for the backoffice, which holds no user credential — its
+/// authority is possession of the producer credentials, not a role on the project. Naming that
+/// bypass rather than letting a driver call into shared internals keeps the set of unauthenticated
+/// entry points greppable.
 ///
 /// With `dry_run` the project is still resolved, but no mail is sent and no event is dispatched.
-/// The send is the irreversible half — an invite email cannot be recalled — so it sits after the
-/// early return rather than before it, unlike the Stripe call in `apply_ownership_transfer`.
 #[allow(clippy::too_many_arguments)]
-pub async fn apply_user_invite(
+pub async fn create_user_invite_from_backoffice(
+    cache: Arc<dyn ProjectDrivenCache>,
+    email: Arc<dyn ProjectEmailDriven>,
+    event: Arc<dyn EventDrivenBridge>,
+    project_id: &str,
+    invitee_email: &str,
+    role: &ProjectUserRole,
+    ttl: Duration,
+    dry_run: bool,
+) -> Result<()> {
+    apply_user_invite(
+        cache,
+        email,
+        event,
+        &Uuid::new_v4().to_string(),
+        project_id,
+        invitee_email,
+        role,
+        ttl,
+        dry_run,
+    )
+    .await
+}
+
+/// The body shared by `create_user_invite` and `create_user_invite_from_backoffice`.
+///
+/// Private on purpose: it performs no authorization, so every caller must be one of the two named
+/// entry points above, which document the authority they rely on.
+///
+/// With `dry_run` this returns before the send. The email is the irreversible half — an invite
+/// cannot be recalled — so it sits after the early return rather than before it, unlike the Stripe
+/// call in `apply_ownership_transfer`.
+#[allow(clippy::too_many_arguments)]
+async fn apply_user_invite(
     cache: Arc<dyn ProjectDrivenCache>,
     email: Arc<dyn ProjectEmailDriven>,
     event: Arc<dyn EventDrivenBridge>,
@@ -1897,23 +1929,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_should_apply_project_user_invite_without_a_credential() {
+    async fn it_should_create_project_user_invite_from_backoffice() {
         let mut cache = MockProjectDrivenCache::new();
         cache
             .expect_find_by_id()
             .return_once(|_| Ok(Some(Project::default())));
 
+        // No `expect_find_user_permission`: the backoffice entry point must not consult a role,
+        // and mockall panics if it does.
         let mut email = MockProjectEmailDriven::new();
         email.expect_send_invite().return_once(|_, _, _, _| Ok(()));
 
         let mut event = MockEventDrivenBridge::new();
         event.expect_dispatch().return_once(|_| Ok(()));
 
-        let result = apply_user_invite(
+        let result = create_user_invite_from_backoffice(
             Arc::new(cache),
             Arc::new(email),
             Arc::new(event),
-            "invite id",
             "project id",
             "new@user.io",
             &ProjectUserRole::Member,
@@ -1937,11 +1970,10 @@ mod tests {
         let email = MockProjectEmailDriven::new();
         let event = MockEventDrivenBridge::new();
 
-        let result = apply_user_invite(
+        let result = create_user_invite_from_backoffice(
             Arc::new(cache),
             Arc::new(email),
             Arc::new(event),
-            "invite id",
             "project id",
             "new@user.io",
             &ProjectUserRole::Member,
@@ -1953,18 +1985,17 @@ mod tests {
         assert!(result.is_ok());
     }
     #[tokio::test]
-    async fn it_should_fail_apply_project_user_invite_when_project_doesnt_exist() {
+    async fn it_should_fail_create_project_user_invite_from_backoffice_when_project_doesnt_exist() {
         let mut cache = MockProjectDrivenCache::new();
         cache.expect_find_by_id().return_once(|_| Ok(None));
 
         let email = MockProjectEmailDriven::new();
         let event = MockEventDrivenBridge::new();
 
-        let result = apply_user_invite(
+        let result = create_user_invite_from_backoffice(
             Arc::new(cache),
             Arc::new(email),
             Arc::new(event),
-            "invite id",
             "project id",
             "new@user.io",
             &ProjectUserRole::Member,

--- a/src/domain/project/command.rs
+++ b/src/domain/project/command.rs
@@ -624,23 +624,72 @@ pub async fn create_user_invite(
     )
     .await?;
 
-    let Some(project) = cache.find_by_id(&cmd.project_id).await? else {
+    apply_user_invite(
+        cache,
+        email,
+        event,
+        &cmd.id,
+        &cmd.project_id,
+        &cmd.email,
+        &cmd.role,
+        cmd.ttl,
+        false,
+    )
+    .await
+}
+
+/// Creates and sends a project invite, with no authorization check of its own.
+///
+/// Callers are responsible for authorization: `create_user_invite` asserts the caller holds the
+/// `Owner` role, while the backoffice driver is already privileged. Mirrors the split between
+/// `transfer_ownership` and `apply_ownership_transfer`.
+///
+/// With `dry_run` the project is still resolved, but no mail is sent and no event is dispatched.
+/// The send is the irreversible half — an invite email cannot be recalled — so it sits after the
+/// early return rather than before it, unlike the Stripe call in `apply_ownership_transfer`.
+#[allow(clippy::too_many_arguments)]
+pub async fn apply_user_invite(
+    cache: Arc<dyn ProjectDrivenCache>,
+    email: Arc<dyn ProjectEmailDriven>,
+    event: Arc<dyn EventDrivenBridge>,
+    id: &str,
+    project_id: &str,
+    invitee_email: &str,
+    role: &ProjectUserRole,
+    ttl: Duration,
+    dry_run: bool,
+) -> Result<()> {
+    let Some(project) = cache.find_by_id(project_id).await? else {
         return Err(Error::CommandMalformed("invalid project id".into()));
     };
 
     let code = Uuid::new_v4().to_string();
 
-    let expires_in = Utc::now() + cmd.ttl;
+    let expires_in = Utc::now() + ttl;
+
+    if dry_run {
+        // The code is deliberately not logged. It is the bearer token that grants membership, and
+        // this one is discarded unsent — but CLI output gets pasted around, and a code that looks
+        // live invites confusion.
+        info!(
+            project = &project.name,
+            email = invitee_email,
+            role = %role,
+            ?expires_in,
+            "invite to send"
+        );
+        return Ok(());
+    }
 
     email
-        .send_invite(&project.name, &cmd.email, &code, &expires_in)
+        .send_invite(&project.name, invitee_email, &code, &expires_in)
         .await?;
 
     let evt = ProjectUserInviteCreated {
-        id: cmd.id,
+        id: id.to_string(),
         project_id: project.id,
-        email: cmd.email,
-        role: cmd.role.to_string(),
+        email: invitee_email.to_string(),
+        role: role.to_string(),
         code,
         expires_in,
         created_at: Utc::now(),
@@ -1845,6 +1894,86 @@ mod tests {
 
         assert!(result.is_err());
         assert!(matches!(result, Err(Error::Unauthorized(_))));
+    }
+
+    #[tokio::test]
+    async fn it_should_apply_project_user_invite_without_a_credential() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        let mut email = MockProjectEmailDriven::new();
+        email.expect_send_invite().return_once(|_, _, _, _| Ok(()));
+
+        let mut event = MockEventDrivenBridge::new();
+        event.expect_dispatch().return_once(|_| Ok(()));
+
+        let result = apply_user_invite(
+            Arc::new(cache),
+            Arc::new(email),
+            Arc::new(event),
+            "invite id",
+            "project id",
+            "new@user.io",
+            &ProjectUserRole::Member,
+            Duration::from_secs(900),
+            false,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn it_should_not_send_mail_or_dispatch_on_a_dry_run_project_user_invite() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache
+            .expect_find_by_id()
+            .return_once(|_| Ok(Some(Project::default())));
+
+        // No expectations set: mockall panics on any call, so these assert the send and the
+        // dispatch never happen. An invite email is not recallable, which is the whole point of
+        // rehearsing one.
+        let email = MockProjectEmailDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        let result = apply_user_invite(
+            Arc::new(cache),
+            Arc::new(email),
+            Arc::new(event),
+            "invite id",
+            "project id",
+            "new@user.io",
+            &ProjectUserRole::Member,
+            Duration::from_secs(900),
+            true,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn it_should_fail_apply_project_user_invite_when_project_doesnt_exist() {
+        let mut cache = MockProjectDrivenCache::new();
+        cache.expect_find_by_id().return_once(|_| Ok(None));
+
+        let email = MockProjectEmailDriven::new();
+        let event = MockEventDrivenBridge::new();
+
+        let result = apply_user_invite(
+            Arc::new(cache),
+            Arc::new(email),
+            Arc::new(event),
+            "invite id",
+            "project id",
+            "new@user.io",
+            &ProjectUserRole::Member,
+            Duration::from_secs(900),
+            false,
+        )
+        .await;
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -409,11 +409,10 @@ pub async fn invite_user(
         }
     }
 
-    project::command::apply_user_invite(
+    project::command::create_user_invite_from_backoffice(
         cache,
         email_driven,
         event,
-        &Uuid::new_v4().to_string(),
         &project_id,
         &email,
         &role,

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -7,7 +7,7 @@ use include_dir::{include_dir, Dir};
 use kube::ResourceExt;
 use serde_json::json;
 use uuid::Uuid;
-use std::{collections::HashMap, path::{Path, PathBuf}, sync::Arc};
+use std::{collections::HashMap, path::{Path, PathBuf}, sync::Arc, time::Duration};
 use tracing::{error, info};
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
         DEFAULT_CATEGORY, PAGE_SIZE_MAX, auth::{Auth0Driven, Auth0Profile}, event::{
             EventDrivenBridge, ProjectDeleted, ProjectUpdated, ResourceCreated, ResourceDeleted, ResourceUpdated
         }, metadata::{KnownField, MetadataDriven}, project::{
-            self, ProjectStatus, ProjectUserAggregated, ProjectUserProject, StripeDriven, cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice}
+            self, ProjectEmailDriven, ProjectStatus, ProjectUserAggregated, ProjectUserProject, ProjectUserRole, StripeDriven, cache::{ProjectDrivenCache, ProjectDrivenCacheBackoffice}
         }, resource::{
             ResourceStatus, cache::{ResourceDrivenCache, ResourceDrivenCacheBackoffice}, cluster::ResourceDrivenClusterBackoffice, command::{build_key, encode_key}
         }, usage::{UsageReport, UsageReportImpl, cache::UsageDrivenCacheBackoffice}, utils::{self, get_schema_from_crd}
@@ -28,6 +28,7 @@ use crate::{
         k8s::K8sCluster,
         kafka::KafkaProducer,
         metadata::FileMetadata,
+        ses::SESDrivenImpl,
         stripe::StripeDrivenImpl,
     },
 };
@@ -330,6 +331,99 @@ pub async fn transfer_project(
 
     if !dry_run {
         info!(project = &id, owner = &profile.email, "project transferred");
+    }
+
+    Ok(())
+}
+
+pub async fn invite_user(
+    config: BackofficeConfig,
+    project_id: String,
+    email: String,
+    role: String,
+    ttl_min: u64,
+    dry_run: bool,
+) -> Result<()> {
+    let role: ProjectUserRole = role.parse()?;
+
+    let sqlite_cache = Arc::new(SqliteCache::new(Path::new(&config.db_path)).await?);
+    sqlite_cache.migrate().await?;
+
+    let cache: Arc<dyn ProjectDrivenCache> =
+        Arc::new(SqliteProjectDrivenCache::new(sqlite_cache.clone()));
+
+    let auth0: Arc<dyn Auth0Driven> = Arc::new(
+        Auth0DrivenImpl::try_new(
+            &config.auth_url,
+            &config.auth_client_id,
+            &config.auth_client_secret,
+            &config.auth_audience,
+        )
+        .await?,
+    );
+
+    let (
+        Some(ses_access_key_id),
+        Some(ses_secret_access_key),
+        Some(ses_region),
+        Some(ses_verified_email),
+    ) = (
+        &config.ses_access_key_id,
+        &config.ses_secret_access_key,
+        &config.ses_region,
+        &config.ses_verified_email,
+    )
+    else {
+        bail!("an [email] section is required in the cli config to invite a user; the invite code only reaches the invitee by mail")
+    };
+
+    let email_driven: Arc<dyn ProjectEmailDriven> = Arc::new(SESDrivenImpl::new(
+        ses_access_key_id,
+        ses_secret_access_key,
+        ses_region,
+        ses_verified_email,
+    ));
+
+    let event = Arc::new(KafkaProducer::new(
+        &config.topic_events,
+        &config.kafka_producer,
+    )?);
+
+    if cache.find_by_id(&project_id).await?.is_none() {
+        bail!("Failed to locate project")
+    };
+
+    // An invite to someone who is already a member is a dead letter: `accept_user_invite` rejects
+    // it with "user already is in the project", so they would get mail they can never act on. An
+    // empty profile is not a problem — the invitee may have no account yet, which is the point.
+    let profile = auth0.find_info(&format!("email:{email}")).await?;
+    if let Some(profile) = profile.first() {
+        if let Some(permission) = cache
+            .find_user_permission(&profile.user_id, &project_id)
+            .await?
+        {
+            bail!(
+                "{email} is already a {} of this project; an invite would be rejected on acceptance",
+                permission.role
+            )
+        }
+    }
+
+    project::command::apply_user_invite(
+        cache,
+        email_driven,
+        event,
+        &Uuid::new_v4().to_string(),
+        &project_id,
+        &email,
+        &role,
+        Duration::from_secs(ttl_min * 60),
+        dry_run,
+    )
+    .await?;
+
+    if !dry_run {
+        info!(project = &project_id, user = &email, "project user invited");
     }
 
     Ok(())
@@ -1164,6 +1258,12 @@ pub struct BackofficeConfig {
     /// Only populated when the config carries a `[stripe]` section; required by `transfer_project`.
     pub stripe_url: Option<String>,
     pub stripe_api_key: Option<String>,
+
+    /// Only populated when the config carries an `[email]` section; required by `invite_user`.
+    pub ses_access_key_id: Option<String>,
+    pub ses_secret_access_key: Option<String>,
+    pub ses_region: Option<String>,
+    pub ses_verified_email: Option<String>,
 
     pub topic_events: String,
     pub kafka_producer: HashMap<String, String>,


### PR DESCRIPTION
## Why

Inviting a user is the one project-membership operation that was reachable only through the Console. Over gRPC it needs an Auth0 bearer token for a member holding the `owner` role — API keys are rejected outright by `assert_credential` (`"project rpc doesnt support secret"`), and the interceptor has no service-account branch. So a project whose owner-role members are all unreachable had no path to gaining one.

That is the same gap `transfer-project` was built to close, and this closes the other half of it.

## What

Two named entry points over one private body:

| Function | Authority | Caller |
|---|---|---|
| `create_user_invite` | asserts `Owner` on the project | gRPC / Console |
| `create_user_invite_from_backoffice` | possession of the producer credentials | backoffice CLI |
| `apply_user_invite` *(private)* | none — performs no authorization | the two above |

Keeping the core private means every unauthenticated path into it is a named function that documents the authority it relies on, rather than a driver reaching into shared internals. Event ids are minted in the domain alongside the others.

```sh
cli --config state/config.toml invite-user \
  --id <project-id> --email someone@example.com --role member --ttl-min 15 --dry-run
```

`--role` defaults to `member`, `--ttl-min` to 15 (matching `invite_ttl_min` in the RPC config). No behaviour change on the Console path — same core, same arguments.

## Two details worth review

**`--dry-run` returns before the send, not after.** In `apply_ownership_transfer` the external call (Stripe) sits *after* the dry-run early return because it is reversible and idempotent. An invite email is neither — it cannot be recalled — so the rehearsal stops before anything leaves the process. Tests enforce this by leaving `MockProjectEmailDriven` and `MockEventDrivenBridge` with no expectations set, so mockall panics if either is touched.

The dry run does still require the `[email]` config section. That is deliberate: a rehearsal that passes without SES credentials and then fails on the real run is worse than no rehearsal.

**The driver refuses to invite an existing member.** `accept_user_invite` rejects those with `"user already is in the project"`, so the mail would be a dead letter — the invitee gets a link that cannot work. The guard resolves the email through Auth0 first; an *empty* profile is explicitly fine, since inviting someone with no Demeter account yet is the common case.

The invite code is deliberately not logged on a dry run. It is discarded unsent and therefore harmless, but CLI output gets pasted around and a live-looking code invites confusion.

## Config

Adds an optional `[email]` section (`ses_access_key_id`, `ses_secret_access_key`, `ses_region`, `ses_verified_email`), mirroring `[stripe]`. Optional, so every other subcommand — including the billing cron — keeps working without it. Example added to `examples/config/cli.toml`.

## Rollout

Nothing to deploy. `ProjectUserInviteCreated` is an existing event with an existing projection and an existing Slack arm; no consumer changes and no new event key. The CLI is built and run locally.

## Testing

`cargo test --lib` — 161 passed, including three new cases: the backoffice entry point invites without consulting a role (`find_user_permission` left unmocked, so a lookup would panic), a dry run sends and dispatches nothing, and an unknown project id errors. Existing `create_user_invite` tests are unchanged and still cover the credential and role gates, which is the point of leaving that wrapper intact.

## Follow-up, not in this PR

`apply_ownership_transfer` (#276) has the shape this PR moves away from: a public no-authorization core that the driver calls directly. Worth giving it the same treatment for consistency, but not while it is the code path behind two transfers already applied in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)