### PR TITLE
feat(cli): default backoffice invites to a week, configurable

### DIFF
--- a/examples/config/cli.toml
+++ b/examples/config/cli.toml
@@ -23,7 +23,7 @@ api_key = ""
 
 # Only needed by invite-user
 [email]
-# Default invite lifetime in minutes; --ttl-min overrides it per invite. Omit for 15.
+# Default invite lifetime in minutes; --ttl-min overrides it per invite. Omit for one week.
 invite_ttl_min = 10080
 ses_access_key_id = "xxx"
 ses_secret_access_key = "xxx"

--- a/examples/config/cli.toml
+++ b/examples/config/cli.toml
@@ -23,6 +23,8 @@ api_key = ""
 
 # Only needed by invite-user
 [email]
+# Default invite lifetime in minutes; --ttl-min overrides it per invite. Omit for 15.
+invite_ttl_min = 10080
 ses_access_key_id = "xxx"
 ses_secret_access_key = "xxx"
 ses_region = "us-west-2"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -91,7 +91,7 @@ pub struct InviteUserArgs {
     #[arg(short, long, default_value = "member")]
     pub role: String,
 
-    /// Minutes the invite code stays valid. Defaults to [email].invite_ttl_min, then to 15.
+    /// Minutes the invite code stays valid. Defaults to [email].invite_ttl_min, then to one week.
     #[arg(short, long)]
     pub ttl_min: Option<u64>,
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -91,9 +91,9 @@ pub struct InviteUserArgs {
     #[arg(short, long, default_value = "member")]
     pub role: String,
 
-    /// Minutes the invite code stays valid
-    #[arg(short, long, default_value_t = 15)]
-    pub ttl_min: u64,
+    /// Minutes the invite code stays valid. Defaults to [email].invite_ttl_min, then to 15.
+    #[arg(short, long)]
+    pub ttl_min: Option<u64>,
 
     // Dry run
     #[arg(short, long, action)]
@@ -448,6 +448,8 @@ struct EmailConfig {
     ses_secret_access_key: String,
     ses_region: String,
     ses_verified_email: String,
+    /// Default lifetime for `invite-user`, in minutes. Optional; `--ttl-min` wins when given.
+    invite_ttl_min: Option<u64>,
 }
 #[derive(Debug, Clone, Deserialize)]
 struct Config {
@@ -492,6 +494,7 @@ impl From<Config> for BackofficeConfig {
                 .map(|e| e.ses_secret_access_key.clone()),
             ses_region: value.email.as_ref().map(|e| e.ses_region.clone()),
             ses_verified_email: value.email.as_ref().map(|e| e.ses_verified_email.clone()),
+            invite_ttl_min: value.email.as_ref().and_then(|e| e.invite_ttl_min),
             topic_events: value.topic_events,
             kafka_producer: value.kafka_producer,
         }

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -336,15 +336,29 @@ pub async fn transfer_project(
     Ok(())
 }
 
+/// Used when neither `--ttl-min` nor `[email].invite_ttl_min` says otherwise. Matches the RPC's
+/// own default, so an invite sent from the backoffice behaves like one sent from the Console.
+const DEFAULT_INVITE_TTL_MIN: u64 = 15;
+
 pub async fn invite_user(
     config: BackofficeConfig,
     project_id: String,
     email: String,
     role: String,
-    ttl_min: u64,
+    ttl_min: Option<u64>,
     dry_run: bool,
 ) -> Result<()> {
     let role: ProjectUserRole = role.parse()?;
+
+    let ttl_min = ttl_min
+        .or(config.invite_ttl_min)
+        .unwrap_or(DEFAULT_INVITE_TTL_MIN);
+
+    // A zero ttl mails a code that has already expired, and the failure only shows up when the
+    // invitee clicks it. Refuse before spending the send.
+    if ttl_min == 0 {
+        bail!("--ttl-min must be greater than zero; the invite would expire before it was read")
+    }
 
     let sqlite_cache = Arc::new(SqliteCache::new(Path::new(&config.db_path)).await?);
     sqlite_cache.migrate().await?;
@@ -1263,6 +1277,8 @@ pub struct BackofficeConfig {
     pub ses_secret_access_key: Option<String>,
     pub ses_region: Option<String>,
     pub ses_verified_email: Option<String>,
+    /// Default invite lifetime, overridden per invite by `--ttl-min`.
+    pub invite_ttl_min: Option<u64>,
 
     pub topic_events: String,
     pub kafka_producer: HashMap<String, String>,

--- a/src/drivers/backoffice/mod.rs
+++ b/src/drivers/backoffice/mod.rs
@@ -336,9 +336,14 @@ pub async fn transfer_project(
     Ok(())
 }
 
-/// Used when neither `--ttl-min` nor `[email].invite_ttl_min` says otherwise. Matches the RPC's
-/// own default, so an invite sent from the backoffice behaves like one sent from the Console.
-const DEFAULT_INVITE_TTL_MIN: u64 = 15;
+/// Used when neither `--ttl-min` nor `[email].invite_ttl_min` says otherwise.
+///
+/// A week rather than the RPC's 15 minutes. A Console invite is sent by someone watching the
+/// screen, who can resend on the spot; a backoffice invite goes out on an operator's schedule to
+/// someone who may not be expecting it, so the window has to survive a weekend. The cost of the
+/// longer window is a code that stays valid longer — it is single-use and bound to one address,
+/// and `--ttl-min` narrows it when that matters.
+const DEFAULT_INVITE_TTL_MIN: u64 = 7 * 24 * 60;
 
 pub async fn invite_user(
     config: BackofficeConfig,


### PR DESCRIPTION
## Why

`invite-user` (#278) took its lifetime only from `--ttl-min`, defaulting to 15 minutes. Two problems, and the second is the real one.

**The default was wrong for this caller.** 15 minutes is inherited from the RPC, where it fits: a Console invite is sent by someone watching the screen, who notices an expiry and resends on the spot. A backoffice invite goes out on an operator's schedule to someone who may not be expecting it — nobody is watching, and the first sign of trouble is the invitee clicking a dead link days later. The window has to survive a weekend.

**There was no way to set a standing policy.** An operator wanting week-long invites had to remember the flag every time, and forgetting it fell back to 15 minutes silently. Worse, the `[email]` section of the CLI config already carries an `invite_ttl_min` key — operators populate that section by copying it out of the RPC's `rpc.toml`, where the key is live — so the config *looked* like it controlled this and didn't.

## What

Default is now **one week**, written as `7 * 24 * 60` so it reads as a duration rather than a magic number. Precedence: `--ttl-min` → `[email].invite_ttl_min` → one week.

```toml
[email]
invite_ttl_min = 10080   # optional; omit for the same thing
```

The RPC keeps its 15 minutes — this constant is backoffice-only, and the divergence is deliberate and documented at the constant.

Also refuses `--ttl-min 0`. That mails a code which has already expired, and the failure surfaces only when the invitee clicks it — worth catching before spending the send rather than after.

Resolution lives in the backoffice driver rather than the binary, so the precedence rule sits next to the config that feeds it and the binary just forwards an `Option`.

## Trade-off

A longer window means a valid code sits in a mailbox for longer. It is single-use and bound to one email address, which `accept_user_invite` checks against the Auth0 profile, so the exposure is a stolen-mailbox scenario — in which the attacker has the account anyway. `--ttl-min` narrows it for a sensitive invite.

## Testing

`cargo test --lib` — 161 passed, unchanged. This is config plumbing over the paths #278 already covers: the TTL reaches `apply_user_invite` as the same `Duration`, and the existing dry-run test still pins that nothing is sent. Verified `--help` renders the fallback and that omitting both flag and key yields a week.

## Not in this PR

The Console's 15 minutes has the same smell, and it is one line in `.github/iac/main.tf:59`. Left alone: it changes invite behaviour for every customer and needs a deploy, so it deserves its own decision rather than riding along with a backoffice change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)